### PR TITLE
[RFC] more-keys extension

### DIFF
--- a/Grammar.pm6
+++ b/Grammar.pm6
@@ -15,7 +15,7 @@ grammar gCNI {
 		['#' | ';'] \V* # until vertical space
 	}
 	token key {
-		[<[a..zA..Z0..9_\-]>+]+ % '.' # alphanum + _- separated by '.'
+		[<-[\s#;\[\]=\.`]>+]+ % '.' # chars other than white space, "#", ";", "[", "]", "=", or "." separated by '.'
 		{ make ~$/; }
 	}
 	token value {

--- a/Grammar.pm6
+++ b/Grammar.pm6
@@ -15,7 +15,7 @@ grammar gCNI {
 		['#' | ';'] \V* # until vertical space
 	}
 	token key {
-		[<-[\s#;\[\]=\.`]>+]+ % '.' # chars other than white space, "#", ";", "[", "]", "=", or "." separated by '.'
+		[<[a..zA..Z0..9_\-]>+]+ % '.' # alphanum + _- separated by '.'
 		{ make ~$/; }
 	}
 	token value {

--- a/SPEC.md
+++ b/SPEC.md
@@ -63,6 +63,10 @@ All extensions are fully optional:
 * Application authors should only mention any extensions that are important to the functioning of their application.
 * Application end-users should not rely on any extensions being present, unless the application they use makes it clear that said extension is available.
 
+### more-keys
+If this extension is used, keys may be composed of any characters which are not whitespace, `#`, `=`, `[`, `]`, or <code>`</code>.
+The meaning and restrictions of dots are unchanged.
+
 ## API
 This API is purely a suggestion for the sake of users - implementations may follow any scheme they wish.
 

--- a/tests/ext/more-keys.cni
+++ b/tests/ext/more-keys.cni
@@ -4,3 +4,6 @@
 path/to/a/file = some metadata # wow
 C:\windows\paths\work = too
 クッキー = nice
+[applie{$}%to]
+section~headings = as well
+do!some?funny = things

--- a/tests/ext/more-keys.cni
+++ b/tests/ext/more-keys.cni
@@ -1,0 +1,6 @@
+# keys can now also contain other characters (but never `[`, `]`, `=`, `#`, or white space; if `ini` is implemented also not `;`)
+# because raw keys also do not exist, backticks are also prohibited in keys to "fail fast"
+# ini style comments are not tested
+path/to/a/file = some metadata # wow
+C:\windows\paths\work = too
+クッキー = nice

--- a/tests/ext/more-keys.json
+++ b/tests/ext/more-keys.json
@@ -1,0 +1,1 @@
+{"path/to/a/file": "some metadata","C:\\windows\\paths\\work": "too","クッキー": "nice"}

--- a/tests/ext/more-keys.json
+++ b/tests/ext/more-keys.json
@@ -1,1 +1,7 @@
-{"path/to/a/file": "some metadata","C:\\windows\\paths\\work": "too","クッキー": "nice"}
+{
+	"path/to/a/file": "some metadata",
+	"C:\\windows\\paths\\work": "too",
+	"クッキー": "nice",
+	"applie{$}%to.section~headings": "as well",
+	"applie{$}%to.do!some?funny": "things"
+}


### PR DESCRIPTION
With this extension, keys can also contain other characters (but never `[`, `]`, `=`, `#`, or white space; if `ini` is implemented also not `;`). Since this extension does not implement raw keys, backticks are also not allowed.

Implementing the extension in the reference grammar makes these tests fail:
- https://github.com/libuconf/cni/blob/17f26607e471c938aeeab4833c9d89de9cccc946/tests/core/unicode_fail.cni#L2 because full Unicode can be used in keys (barring code points with special meaning as above)
- https://github.com/libuconf/cni/blob/17f26607e471c938aeeab4833c9d89de9cccc946/tests/core/key/07_fail.cni#L3 because `k$y` is a valid key with this extension
- https://github.com/libuconf/cni/blob/17f26607e471c938aeeab4833c9d89de9cccc946/tests/core/section/07_fail.cni#L3 because `s$ction` is a valid section name with this extension