### PR TITLE
fix unterminated raw value test (core/raw/04_fail)

### DIFF
--- a/tests/core/raw/04_fail.cni
+++ b/tests/core/raw/04_fail.cni
@@ -5,4 +5,4 @@ raw = `
 # this is one of the reasons most users should be encouraged to use barewords
 # unless you can accurately determine why it failed
 # *and* print a good error message
-# "expected to see ` but found EOF" is NOT a good error message
+# "expected to see backtick but found EOF" is NOT a good error message


### PR DESCRIPTION
Because of the now removed backtick, the error would actually be that there is a missing equal sign in between "but" and "found". The start of the raw value makes the lines starting with octothorpes not actual comments, thus the "commented" backtick is not actually commented out.